### PR TITLE
Mirror of github hub PR IssueNumber 2625

### DIFF
--- a/commands/issue.go
+++ b/commands/issue.go
@@ -17,7 +17,7 @@ var (
 	cmdIssue = &Command{
 		Run: listIssues,
 		Usage: `
-issue [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>]
+issue list [-a <ASSIGNEE>] [-c <CREATOR>] [-@ <USER>] [-s <STATE>] [-f <FORMAT>] [-M <MILESTONE>] [-l <LABELS>] [-d <DATE>] [-o <SORT_KEY> [-^]] [-L <LIMIT>]
 issue show [-f <FORMAT>] <NUMBER>
 issue create [-oc] [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>]
 issue update <NUMBER> [-m <MESSAGE>|-F <FILE>] [--edit] [-a <USERS>] [-M <MILESTONE>] [-l <LABELS>] [-s <STATE>]
@@ -28,7 +28,10 @@ issue transfer <NUMBER> <REPO>
 
 ## Commands:
 
-With no arguments, show a list of open issues.
+With no arguments, performs ''hub issue list''
+
+	* _list_:
+		Show a list of open issues for the current repository.
 
 	* _show_:
 		Show an existing issue specified by <NUMBER>.
@@ -196,6 +199,26 @@ hub-pr(1), hub(1)
 `,
 	}
 
+	cmdListIssue = &Command{
+		Key: "list",
+		Run: listIssues,
+		KnownFlags: `
+		-a, --assignee USER
+		-s, --state STATE
+		-f, --format FMT
+		-M, --milestone NAME
+		-c, --creator USER
+		-@, --mentioned USER
+		-l, --labels LIST
+		-d, --since DATE
+		-o, --sort KEY
+		-^, --sort-ascending
+		--include-pulls
+		-L, --limit N
+		--color
+`,
+	}
+
 	cmdCreateIssue = &Command{
 		Key: "create",
 		Run: createIssue,
@@ -249,6 +272,7 @@ hub-pr(1), hub(1)
 )
 
 func init() {
+	cmdIssue.Use(cmdListIssue)
 	cmdIssue.Use(cmdShowIssue)
 	cmdIssue.Use(cmdCreateIssue)
 	cmdIssue.Use(cmdLabel)

--- a/commands/pr.go
+++ b/commands/pr.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	cmdPr = &Command{
-		Run: printHelp,
+		Run: listPulls,
 		Usage: `
 pr list [-s <STATE>] [-h <HEAD>] [-b <BASE>] [-o <SORT_KEY> [-^]] [-f <FORMAT>] [-L <LIMIT>]
 pr checkout <PR-NUMBER> [<BRANCH>]
@@ -24,6 +24,8 @@ pr merge [-d] [--squash | --rebase] <PR-NUMBER> [-m <MESSAGE> | -F <FILE>] [--he
 		Long: `Manage GitHub Pull Requests for the current repository.
 
 ## Commands:
+
+With no arguments, performs ''hub pr list''
 
 	* _list_:
 		List pull requests in the current repository.
@@ -225,10 +227,6 @@ func init() {
 	cmdPr.Use(cmdShowPr)
 	cmdPr.Use(cmdMergePr)
 	CmdRunner.Use(cmdPr)
-}
-
-func printHelp(command *Command, args *Args) {
-	utils.Check(command.UsageError(""))
 }
 
 func listPulls(cmd *Command, args *Args) {

--- a/commands/release.go
+++ b/commands/release.go
@@ -17,7 +17,7 @@ var (
 	cmdRelease = &Command{
 		Run: listReleases,
 		Usage: `
-release [--include-drafts] [--exclude-prereleases] [-L <LIMIT>] [-f <FORMAT>]
+release list [--include-drafts] [--exclude-prereleases] [-L <LIMIT>] [-f <FORMAT>]
 release show [-f <FORMAT>] <TAG>
 release create [-dpoc] [-a <FILE>] [-m <MESSAGE>|-F <FILE>] [-t <TARGET>] <TAG>
 release edit [<options>] <TAG>
@@ -28,7 +28,13 @@ release delete <TAG>
 
 ## Commands:
 
-With no arguments, shows a list of existing releases.
+With no arguments, performs ''hub release list''
+
+	* _list_:
+		Show a list of existing releases for the current repository.
+
+		With  --include-drafts,  include  draft  releases  in the listing. With
+		--prereleases, exclude non-stable releases from the listing.
 
 	* _show_:
 		Show GitHub release notes for <TAG>.
@@ -172,6 +178,18 @@ hub(1), git-tag(1)
 `,
 	}
 
+	cmdListRelease = &Command{
+		Key: "list",
+		Run: listReleases,
+		KnownFlags: `
+		-d, --include-drafts
+		-p, --exclude-prereleases
+		-L, --limit N
+		-f, --format FMT
+		--color
+`,
+	}
+
 	cmdShowRelease = &Command{
 		Key: "show",
 		Run: showRelease,
@@ -227,6 +245,7 @@ hub(1), git-tag(1)
 )
 
 func init() {
+	cmdRelease.Use(cmdListRelease)
 	cmdRelease.Use(cmdShowRelease)
 	cmdRelease.Use(cmdCreateRelease)
 	cmdRelease.Use(cmdEditRelease)


### PR DESCRIPTION
Mirror of github hub PR IssueNumber 2625
This makes `hub pr` equivalent to `hub pr list`, and adds the subcomand `hub {issue,release} list` as an alias to `hub {issue,release}`

Let me know if you think this is good enough to merge!

Hacktoberfest!
